### PR TITLE
TST: clean up pysat install on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ dist: xenial
 matrix:
   include:
     - python: 2.7
-    - python: 3.5
     - python: 3.6
     - python: 3.7
+    - python: 3.8
 
 services: xvfb
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,18 +22,10 @@ before_install:
   - pip install xarray
   - pip install matplotlib
   - pip install apexpy
-
-  # Prepare modified pysat install
   - pip install numpy
-  - cd ..
-  - echo 'cloning pysat'
-  - git clone https://github.com/pysat/pysat.git >/dev/null
-  - echo 'installing pysat'
-  - cd ./pysat
+  - pip install 'pysat>=2.1.0'
   # set up data directory
   - mkdir /home/travis/build/pysatData
-  # install pysat
-  - python setup.py install >/dev/null
 
   # install pyglow, space science models
   - cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ before_install:
   - pip install matplotlib
   - pip install apexpy
   - pip install numpy
+  
   - pip install 'pysat>=2.1.0'
   # set up data directory
   - mkdir /home/travis/build/pysatData

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [0.2.0] - 2019-10-26
 - Added support for readthedocs
+- Updates to testing environment
 
 ## [0.1.1] - 2019-10-22
 - pypi compatibility


### PR DESCRIPTION
# Description

Pysat 2.1.0 is now available via pip.  There is no longer a need for the custom pysat install, so the pysat family of codes is being upgraded to a "standard" installation through pip.  This will allow the `no_sgp4` branch of pysat to be deleted.

## Type of change

- Test environment update

# How Has This Been Tested?

Updates to Travis-CI environment, so tested there.

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``master``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
